### PR TITLE
Set link-preview description on the Left of the Loop series page

### DIFF
--- a/series-left-of-the-loop.md
+++ b/series-left-of-the-loop.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "Left of the Loop"
+description: "AI erodes the incidental friction that used to produce shared understanding as a byproduct of the work. That makes shared understanding the scarce resource, and constructive friction the mechanism that protects and tests it. Implementation getting radically cheaper is why this is happening now, and at scale. The organizations that preserve the constructive kind will outperform the ones that optimize it away."
 permalink: /series/left-of-the-loop/
 ---
 


### PR DESCRIPTION
## Summary
- `series-left-of-the-loop.md` had no page-level `description:` front matter, so `jekyll-seo-tag`'s `{% seo %}` fell back to the site-wide `description` in `_config.yml` — the consulting/workshops bio — as the `og:description`/`twitter:description` shown in link-preview cards.
- Adds `description:` set to the series thesis, so sharing the series link shows the actual argument instead of the personal bio blurb.

## Test plan
- [ ] Build the site and inspect the rendered `<head>` for `/series/left-of-the-loop/` to confirm `og:description` and `twitter:description` now contain the thesis text instead of the site-wide bio.
- [ ] Paste the series URL into a tool that renders link previews (e.g. Slack, a social platform) to sanity-check the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)