### PR TITLE
Give the Left of the Loop series page a punchier SEO title

### DIFF
--- a/series-left-of-the-loop.md
+++ b/series-left-of-the-loop.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "Left of the Loop"
+seo_title: "Left of the Loop: The Room AI Can't Replace"
 description: "AI erodes the incidental friction that used to produce shared understanding as a byproduct of the work. That makes shared understanding the scarce resource, and constructive friction the mechanism that protects and tests it. Implementation getting radically cheaper is why this is happening now, and at scale. The organizations that preserve the constructive kind will outperform the ones that optimize it away."
 permalink: /series/left-of-the-loop/
 ---


### PR DESCRIPTION
## Summary
- Adds `seo_title: "Left of the Loop: The Room AI Can't Replace"` to `series-left-of-the-loop.md`.
- `jekyll-seo-tag` uses `page.seo_title` (falling back to `page.title`) to build `<title>`, `og:title`, and `twitter:title`, so this only changes what shows up in link previews and search results — the on-page H1 and the manually-built `<title>` tag in `_layouts/default.html` still use `page.title` ("Left of the Loop"), unaffected.
- Picked this phrasing because it echoes "the room" language used throughout the series (Spec Sessions, the Agora, etc.) rather than just restating the series name, and it's short enough to survive truncation once `| Simon Schrottner` is appended.

Builds on #8, which set the page's `description` to the series thesis.

## Test plan
- [ ] Build the site and inspect `/series/left-of-the-loop/`'s `<head>` to confirm `<title>`, `og:title`, and `twitter:title` reflect the new seo_title, while the page's visible H1 still reads "Left of the Loop".

🤖 Generated with [Claude Code](https://claude.com/claude-code)