### PR TITLE
Add a speaker offering and surface Left of the Loop on the front page

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -221,3 +221,11 @@ Devs
 WeAreDevelopers
 there'll
 leftoftheloop.dev
+KCD
+Sofia
+Hamburg
+Lock-In
+co-delivered
+kcd.bg
+CloudNativeCon
+organizers

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Simon Schrottner
-description: OpenFeature maintainer & CNCF Ambassador. Consulting and workshops on feature flagging, developer experience, and open-standards adoption — Austria, DACH region and remote.
+description: OpenFeature maintainer & CNCF Ambassador. Speaking, consulting, and workshops on feature flagging, developer experience, and open-standards adoption — Austria, DACH region and remote.
 author:
   name: Simon Schrottner
   email: simon@schrottner.at

--- a/about.md
+++ b/about.md
@@ -15,7 +15,7 @@ My mission: help teams release faster and with more confidence. That comes from 
 - **OpenFeature maintainer** — the vendor-neutral standard for feature flagging in the CNCF landscape. Active across the org in Java, Python, Go, and JavaScript.
 - **CNCF Ambassador** — advocating for cloud-native practices and helping bridge between projects and users.
 - **JUnit Pioneer maintainer** — a JUnit 5 extension pack.
-- **Speaker** — KubeCon, Devoxx, JavaCro, JCON, Cloudland, ContainerDays, and meetups across Europe.
+- **Speaker** — KubeCon, Devoxx, JavaCro, JCON, Cloudland, ContainerDays, and meetups across Europe. Available to hire for conferences and in-house events.
 - **Consulting & workshops** — see [services]({{ '/services/' | relative_url }}) for what that looks like in practice.
 
 ## Background
@@ -28,7 +28,7 @@ The thread across all of it: I care most about the people. Helping engineers gro
 
 ## Speaking
 
-I speak regularly on feature flagging, observability, and developer experience. Full list with abstracts on [/talks]({{ '/talks/' | relative_url }}) or [Sessionize](https://sessionize.com/simon-schrottner).
+I speak regularly on feature flagging, observability, and developer experience — and I can be hired for conferences, meetups, and internal engineering events. Topics, formats, and upcoming dates on [/talks]({{ '/talks/' | relative_url }}); full session catalogue on [Sessionize](https://sessionize.com/simon-schrottner).
 
 ## Outside work
 

--- a/index.md
+++ b/index.md
@@ -19,20 +19,31 @@ Based in Pernegg an der Mur, Austria. Available for consulting across the DACH r
 - **Feature flagging workshops** — get teams from ad-hoc toggles to a flagging strategy they can trust in production.
 - **Developer experience advisory** — fractional input on tooling, testing, and the unglamorous plumbing that decides whether your release cycle is a strength or a tax.
 - **Implementation consulting** — hands-on rollout of OpenFeature, observability integration, and the glue work that ties them together.
+- **Talks & keynotes** — conference sessions, keynotes, and in-house talks, delivered from inside the projects rather than from the outside looking in.
 
 [More on services →]({{ '/services/' | relative_url }})
+
+## Speaking
+
+I'm available to hire as a speaker — conferences, meetups, and internal engineering events, in English or German.
+
+Next up: **ContainerDays Hamburg** (Sep 2–4), **KCD Sofia** (Sep 29), and **KubeCon NA** in Salt Lake City (Nov 9–12). Previously KubeCon EU, Devoxx, DevoxxUK, JavaCro, JCON, Cloudland, JNation, and meetups across Europe.
+
+[Topics, formats, and booking →]({{ '/talks/' | relative_url }})
+
+## Left of the Loop
+
+The question I'm chasing right now: AI is stripping out the incidental friction that used to produce shared understanding as a byproduct of building software. That makes shared understanding the scarce resource — and pushes engineering work *left*, toward defining what a system should do before anything gets built.
+
+*Left of the Loop* is where I'm working that out in public. It's a series in progress, and it's the direction I want to take my own practice, my talks, and the teams I work with.
+
+[Read the series →]({{ '/series/left-of-the-loop/' | relative_url }})
 
 ## Writing
 
 Occasional notes on feature flagging, observability, and where open standards are heading.
 
 [Read the blog →]({{ '/blog/' | relative_url }})
-
-## Recent stages
-
-KubeCon EU, Devoxx, DevoxxUK, JavaCro, JCON, Cloudland, ContainerDays, JNation, and meetups across Europe.
-
-[Full speaking history →]({{ '/talks/' | relative_url }})
 
 ## Work with me
 

--- a/services.md
+++ b/services.md
@@ -6,7 +6,7 @@ permalink: /services/
 
 # Services
 
-I work with engineering teams that want to release faster and with more confidence. Most engagements sit in one of three shapes — but the goal is always the same: less guesswork in production, more trust in the release process.
+I work with engineering teams that want to release faster and with more confidence. Most engagements sit in one of four shapes — but the goal is always the same: less guesswork in production, more trust in the release process.
 
 ## Feature flagging workshops
 
@@ -25,6 +25,16 @@ Fractional, ongoing input on the parts of the engineering org that determine whe
 OpenFeature, end-to-end, from a maintainer's perspective. Hands-on rollout work: integrating OpenFeature into your stack, wiring it into OpenTelemetry for SRE-grade observability, building the internal tooling around evaluation and audit, and unblocking edge cases by going to the source. As one of the project's maintainers I can shape the spec where it needs to bend — and help the in-house team carry the work forward after I'm gone.
 
 **Who it's for:** teams adopting OpenFeature without in-house insider context, and anyone hitting the edges where the spec meets reality.
+
+## Speaking — talks & keynotes
+
+Conference sessions, keynotes, and in-house talks on feature flagging, observability, developer experience, open standards, and where engineering work is moving in the age of agents. I speak as a CNCF Ambassador and OpenFeature maintainer, which means the material comes from inside the projects — and from having had to make it work in production first. English or German, solo or co-delivered.
+
+Recent stages include KubeCon, Devoxx, ContainerDays, JNation, Cloudland, and JavaCro. Community conferences and meetups are usually travel-only; corporate events and internal sessions are paid engagements.
+
+**Who it's for:** conference organizers looking for a session that isn't a vendor pitch, and engineering orgs who want an outside voice to open an internal event or a company-wide session.
+
+[Upcoming dates, topics, and formats →]({{ '/talks/' | relative_url }})
 
 ## How to get in touch
 

--- a/talks.md
+++ b/talks.md
@@ -6,7 +6,45 @@ permalink: /talks/
 
 # Talks
 
-I speak regularly on feature flagging, observability, developer experience, and the craft of open standards. Slides and abstracts for most talks live on [Sessionize](https://sessionize.com/simon-schrottner) — recordings and decks linked below where available.
+I speak regularly on feature flagging, observability, developer experience, and the craft of open standards — and I'm available to hire for conferences, meetups, and in-house sessions. Slides and abstracts for most talks live on [Sessionize](https://sessionize.com/simon-schrottner) — recordings and decks linked below where available.
+
+## Upcoming
+
+- **ContainerDays Hamburg 2026** — Sep 2–4, Hamburg. *Fun with Flags: How OpenFeature Solves Your Feature Flag Headaches.* [Conference](https://www.containerdays.io/containerdays-hamburg-2026/speakers/) · [Slides](https://schrottner.at/openFeatureTalk/)
+- **KCD Sofia 2026** — Sep 29, Sofia. *Your Open Source Standard Is Just Another Lock-In.* [Conference](https://kcd.bg/)
+- **KubeCon + CloudNativeCon NA 2026** — Nov 9–12, Salt Lake City. *OpenFeature as a Control Plane for OpenTelemetry.* [Conference](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/)
+
+## Book me for your event
+
+I take the stage as a CNCF Ambassador and an OpenFeature maintainer, which means the talks come from inside the projects rather than from the outside looking in. Every session is built around something I've actually had to make work in production — not a vendor pitch, and never a slide deck read aloud.
+
+### Topics I speak on
+
+- Feature flagging that survives contact with production — patterns, failure modes, and OpenFeature
+- Observability for release confidence — OpenTelemetry, and what SREs actually need to see
+- Developer experience and platform engineering — the plumbing that decides whether shipping is a strength or a tax
+- Open standards, vendor neutrality, and the governance that keeps them honest
+- Shifting engineering left in the age of agents — the [Left of the Loop]({{ '/series/left-of-the-loop/' | relative_url }}) thesis
+
+### Formats
+
+- Conference session (30–45 min) or lightning talk
+- Keynote — including co-delivered keynotes, which I enjoy more than the solo kind
+- Hands-on workshop, half or full day
+- Meetup talk, user group, or podcast/panel
+- In-house session for your engineering org — same material, tuned to your stack and your problems
+
+### Practicalities
+
+- English or German (native), and I'll happily do a German-language keynote
+- Based in Austria; I travel across Europe regularly and further for the right event
+- Community conferences, meetups, and CNCF events are usually travel-only. Corporate events and in-house sessions are paid engagements — [ask me]({{ '/services/' | relative_url }})
+- Give me a rough audience profile and I'll tell you honestly whether one of my sessions fits, or propose something that does
+
+<p class="cta">
+  <a href="mailto:simon@schrottner.at" class="cta-button">Invite me to speak</a>
+  <a href="https://sessionize.com/simon-schrottner" class="cta-button cta-button-secondary">Session catalogue</a>
+</p>
 
 ## Featured
 
@@ -17,18 +55,14 @@ I speak regularly on feature flagging, observability, developer experience, and 
   <p><a href="https://www.youtube.com/watch?v=XhgIwxrtvuo">Watch the recording on YouTube →</a></p>
 </div>
 
-## Upcoming
-
-- **DevoxxUK 2026** — London, May 6–7. *Fun with Flags: How OpenFeature Solves Your Feature Flag Headaches.* [Slides](https://schrottner.at/openFeatureTalk/)
-- **Cloudland 2026** — May 19–22, Heide Park (Germany). [Agenda](https://meine.doag.org/events/cloudland/2026/agenda/)
-  - *Quo vadis Cloud Native – Aufbruch ins zweite Jahrzehnt* — keynote with Mario Fahlandt (Kubermatic). May 20, in German.
-  - *CNCF Showcase: Cloud Native zum Anfassen* — workshop, May 20, in German.
-- **JNation 2026** — May 26–27, Coimbra, Portugal. *Fun with Flags.* [Conference](https://jnation.pt/) · [Slides](https://schrottner.at/openFeatureTalk/)
-- **ContainerDays Hamburg 2026** — Sep 2–4. *Fun with Flags.* [Conference](https://www.containerdays.io/containerdays-hamburg-2026/speakers/) · [Slides](https://schrottner.at/openFeatureTalk/)
-
 ## 2026
 
-- **KubeCon EU 2026** — Amsterdam. *18 Bluetooth Controllers Walk Into a Bar: Observability & Runtime Configuration with CNCF Tools* — with Manuel Timelthaler. [Recording](https://www.youtube.com/watch?v=Y9agHID8Ml4) · [Slides](https://watchmejoustmyflags.github.io/kubecon-material/kubecon-cloudnativecon-europe-presentation)
+- **JNation 2026** — May 26–27, Coimbra, Portugal. *Fun with Flags.* [Conference](https://jnation.pt/) · [Slides](https://schrottner.at/openFeatureTalk/)
+- **Cloudland 2026** — May 19–22, Heide Park (Germany). [Agenda](https://meine.doag.org/events/cloudland/2026/agenda/)
+  - *Quo vadis Cloud Native – Aufbruch ins zweite Jahrzehnt* — keynote with Mario Fahlandt (Kubermatic). In German.
+  - *CNCF Showcase: Cloud Native zum Anfassen* — workshop, in German.
+- **DevoxxUK 2026** — London, May 6–7. *Fun with Flags: How OpenFeature Solves Your Feature Flag Headaches.* [Slides](https://schrottner.at/openFeatureTalk/)
+- **KubeCon EU 2026** — Amsterdam, March. *18 Bluetooth Controllers Walk Into a Bar: Observability & Runtime Configuration with CNCF Tools* — with Manuel Timelthaler. [Recording](https://www.youtube.com/watch?v=Y9agHID8Ml4) · [Slides](https://watchmejoustmyflags.github.io/kubecon-material/kubecon-cloudnativecon-europe-presentation)
 - **Cloud Native Innsbruck 2026** — *Fun with Flags: How OpenFeature Solves Your Feature Flag Headaches.* [Slides](https://schrottner.at/openFeatureTalk/)
 
 ## 2025
@@ -52,4 +86,4 @@ I speak regularly on feature flagging, observability, developer experience, and 
 
 ---
 
-Want me to speak at your event? [Get in touch](mailto:simon@schrottner.at) or check the [Sessionize profile](https://sessionize.com/simon-schrottner) for a session catalogue.
+Want me to speak at your event? [Get in touch](mailto:simon@schrottner.at) with the date, the audience, and roughly what you want them to walk away with — I'll come back honestly about whether I'm the right fit.


### PR DESCRIPTION
The site presented speaking only as a talk archive, even though Simon can be hired as a speaker. This turns `/talks` into a booking page and adds speaking as a fourth service.

## Changes

**`/talks`** — rebuilt as a booking page, not just an archive.
- New **Book me for your event** section: topics, formats (session / keynote / workshop / meetup / in-house), practicalities (languages, travel, fees), and a CTA pair.
- **Upcoming** refreshed to the three actually-upcoming events: ContainerDays Hamburg (Sep 2–4), KCD Sofia (Sep 29), KubeCon NA (Nov 9–12, Salt Lake City). The May 2026 events (DevoxxUK, Cloudland, JNation) had gone stale in "Upcoming" and moved into the 2026 archive.

**`/services`** — speaking is now a fourth engagement shape alongside workshops, advisory, and implementation consulting.

**Front page** — a `Talks & keynotes` bullet under "What I help with", a **Speaking** section leading with the upcoming stages, and a **Left of the Loop** section framing the series as both a project in progress and the direction the practice is heading.

**`/about`, `_config.yml`** — speaker availability in the bio and site description.

## Please check before merging

1. **The fee line is inferred, not stated.** `/talks` and `/services` both say community conferences and meetups are *usually* travel-only, while corporate and in-house sessions are paid engagements. That's a commercial position I guessed at — change it if it's wrong.
2. **KCD Sofia venue** is omitted (the event site doesn't confirm "Sofia Event Center"); the Sep 29 date is confirmed.
3. **Linters were not run locally** — no Node in the dev environment, so CI is the first real check. `KCD`, `Sofia`, `Hamburg`, `Lock-In`, `co-delivered`, `kcd.bg`, `CloudNativeCon`, and `organizers` were added to `.spelling` preemptively.

Event dates verified against [kcd.bg](https://kcd.bg/), [LF Events](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/), and [containerdays.io](https://www.containerdays.io/containerdays-hamburg-2026/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
