### PR TITLE
Bring the loop diagram back into the text column

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -302,12 +302,10 @@ img { max-width: 100%; height: auto; }
 }
 
 /* Diagram figure on the series overview. The artwork is transparent ink, so the
-   image sits on its own white card and stays legible in dark mode too. It also
-   breaks out of the 36rem text column: the labels are unreadable at that width. */
+   image sits on its own white card and stays legible in dark mode too. It sits
+   in the text column; the full-size PNG is a click away for the fine labels. */
 .series-figure {
-  width: min(48rem, calc(100vw - 2.5rem));
-  margin: 2rem 0 2rem 50%;
-  transform: translateX(-50%);
+  margin: 2rem 0;
 }
 
 .series-figure a {


### PR DESCRIPTION
Follow-up to #13. The diagram was set to `min(48rem, 100vw - 2.5rem)`, breaking out past the 36rem text column — wider than both the paragraphs and the hero above it. It read as louder than it needs to be.

This drops it to the column width, which is exactly 75% of what it was (48rem × 0.75 = 36rem). Because that lands precisely on the column, the breakout rules come out entirely and three declarations collapse into one `margin`.

```diff
 .series-figure {
-  width: min(48rem, calc(100vw - 2.5rem));
-  margin: 2rem 0 2rem 50%;
-  transform: translateX(-50%);
+  margin: 2rem 0;
 }
```

The figure now aligns with the text and the hero. Labels get smaller but stay legible, and the image already links to the full-size PNG for the fine print.

## On going further

50% (24rem / 384px) was considered and rejected. At that size "merged record of what and why", "the conversation" and "machine speed" drop below readable — the figure stops explaining anything and becomes decoration you have to click through. 75% keeps them small but legible.

## For the reviewer

CSS-only, one hunk. Same caveat as #13: no Ruby/Jekyll locally, so this has not been rendered by the real site — the comparison I worked from was a mock at page scale. Worth a quick `bundle exec jekyll serve` look, especially on mobile, where the figure now simply fills the column instead of being clamped by the old `100vw - 2.5rem` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
